### PR TITLE
hotfix: db session

### DIFF
--- a/application/container.py
+++ b/application/container.py
@@ -51,8 +51,10 @@ class ServiceFactory:
         Returns:
             ServiceFactory: The singleton instance.
         """
-        if refresh or cls.__instance is None or (session is not None and cls.__instance.session is not session):
-            cls.__instance = cls(session)
+        current_session = session or db.session
+        # Refresh the factory when explicitly requested or when the underlying session changes
+        if refresh or cls.__instance is None or cls.__instance.session is not current_session:
+            cls.__instance = cls(current_session)
         return cls.__instance
 
     def build_user_service(self) -> UserService:


### PR DESCRIPTION
This pull request updates the logic for retrieving the singleton instance of the `ServiceFactory` in `container.py` to ensure better handling of database sessions. The main improvement is to consistently use the current database session, which helps avoid issues when the session changes or is not explicitly provided.

Session management improvements:

* Updated the `get_instance` method in `ServiceFactory` to always use the current database session (`db.session`) if no session is provided, and to refresh the singleton instance if the session changes or if a refresh is explicitly requested.