### PR TITLE
Diary question

### DIFF
--- a/application/services/question_service.py
+++ b/application/services/question_service.py
@@ -147,3 +147,11 @@ class QuestionService:
                 "No hi ha preguntes disponibles a la base de dades."
             )
         return choice(questions)
+
+    def get_diary_question(self) -> Question:
+        question = self.question_repo.get_diary_question()
+        if not question:
+            raise QuestionNotFoundException(
+                "No hi ha cap pregunta del diari disponible a la base de dades."
+            )
+        return question

--- a/domain/repositories/interfaces.py
+++ b/domain/repositories/interfaces.py
@@ -247,6 +247,15 @@ class IQuestionRepository(ABC):
             List[Question]: Questions satisfying the filters.
         """
         raise NotImplementedError()
+    
+    @abstractmethod
+    def get_diary_question(self) -> Question:
+        """
+        Retrieve the diary question.
+        Returns:
+            Question: The diary question.
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def add_many(self, questions: Iterable[Question]) -> None:

--- a/globals.py
+++ b/globals.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 
-VERSION = '0.8.0'
+VERSION = '0.9.0'
 
 DEFAULT_VERSION_ENDPOINT = '/api/version'
 
@@ -58,3 +58,5 @@ SMTP_USERNAME = os.getenv('SMTP_USERNAME')
 SMTP_PASSWORD = os.getenv('SMTP_PASSWORD')
 SMTP_USE_TLS = str(os.getenv('SMTP_USE_TLS', 'true')).lower() in ('t', 'true', '1', 'y', 'yes')
 SMTP_USE_SSL = str(os.getenv('SMTP_USE_SSL', 'false')).lower() in ('t', 'true', '1', 'y', 'yes')
+
+DIARY_QUESTION_ID = "c51fd74b-8940-4bb2-9668-a498e98ffc92"

--- a/helpers/enums/question_types.py
+++ b/helpers/enums/question_types.py
@@ -6,3 +6,4 @@ class QuestionType(Enum):
     WORDS = "words"
     SORTING = "sorting"
     MULTITASKING = "multitasking"
+    DIARY = "diary"

--- a/infrastructure/sqlalchemy/repositories.py
+++ b/infrastructure/sqlalchemy/repositories.py
@@ -28,6 +28,7 @@ from domain.repositories import (
     IUserRepository,
     ITranscriptionAnalysisRepository,
 )
+from globals import DIARY_QUESTION_ID
 from helpers.enums.user_role import UserRole
 from helpers.exceptions.user_exceptions import (
     RelatedUserNotFoundException,
@@ -404,6 +405,10 @@ class SQLAlchemyQuestionRepository(IQuestionRepository):
             query = query.filter(Question.question_type == question_type)
 
         return [self._to_domain(model) for model in query.all()]
+    
+    def get_diary_question(self) -> Optional[QuestionDomain]:
+        diary_question_id = uuid.UUID(DIARY_QUESTION_ID)
+        return self.get(diary_question_id)
 
     def add_many(self, questions: Iterable[QuestionDomain]) -> None:
         for question in questions:

--- a/migrations/versions/bdc3462def1e_add_diary_enum.py
+++ b/migrations/versions/bdc3462def1e_add_diary_enum.py
@@ -1,0 +1,32 @@
+"""add_diary_enum
+
+Revision ID: bdc3462def1e
+Revises: d99fd9fcba9c
+Create Date: 2025-12-12 21:15:33.486244
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'bdc3462def1e'
+down_revision = 'd99fd9fcba9c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Añade el valor 'diary' al enum de question_type
+    op.execute("ALTER TYPE questiontype ADD VALUE 'DIARY'")
+
+
+def downgrade():
+    # PostgreSQL no permite eliminar valores de enum directamente,
+    # por lo que se recrea el tipo sin 'diary'
+    op.execute("ALTER TYPE questiontype RENAME TO questiontype_old")
+    op.create_enum('questiontype', ['CONCENTRATION', 'SPEED', 'WORDS', 'SORTING', 'MULTITASKING'])
+    op.alter_column('questions', 'question_type', type_=sa.Enum('CONCENTRATION', 'SPEED', 'WORDS', 'SORTING', 'MULTITASKING', name='questiontype'), existing_type=sa.Enum('CONCENTRATION', 'SPEED', 'WORDS', 'SORTING', 'MULTITASKING', 'DIARY', name='questiontype_old'))
+    op.alter_column('activities', 'activity_type', type_=sa.Enum('CONCENTRATION', 'SPEED', 'WORDS', 'SORTING', 'MULTITASKING', name='questiontype'), existing_type=sa.Enum('CONCENTRATION', 'SPEED', 'WORDS', 'SORTING', 'MULTITASKING', 'DIARY', name='questiontype_old'))
+    op.execute("DROP TYPE questiontype_old")

--- a/resources/question.py
+++ b/resources/question.py
@@ -348,3 +348,49 @@ class DailyQuestionResource(MethodView):
         except Exception as e:
             self.logger.error("Error inesperat en recuperar preguntes", module="DailyQuestionResource", error=e)
             abort(500, message=f"S'ha produït un error inesperat en recuperar la pregunta diària: {str(e)}")
+
+@blp.route('/diary')
+class DiaryQuestionResource(MethodView):
+    """
+    Endpoints per a la pregunta del diari.
+    """
+
+    logger = AbstractLogger.get_instance()
+
+    @roles_required([UserRole.PATIENT])
+    @blp.doc(
+        summary="Obtenir pregunta del diari.",
+        description=(
+            "Obté la pregunta del diari per al pacient."
+        ),
+    )
+    @blp.response(200, schema=QuestionResponseSchema, description="Pregunta del diari recuperada correctament.")
+    @blp.response(401, description="Falta o és invàlid el JWT.")
+    @blp.response(403, description="Cal ser pacient per accedir a aquest recurs.")
+    @blp.response(404, description="No s'ha trobat la pregunta indicada.")
+    @blp.response(500, description="Error inesperat del servidor en consultar les preguntes.")
+    def get(self):
+        """
+        Obtenir la pregunta del diari.
+        """
+        try:
+            self.logger.info(
+                "Recuperant pregunta del diari",
+                module="DiaryQuestionResource",
+            )
+
+            factory = ServiceFactory.get_instance()
+            question_service = factory.build_question_service()
+            question = question_service.get_diary_question()
+
+            return jsonify(question.to_dict()), 200
+        except QuestionNotFoundException as e:
+            self.logger.error(
+                "Pregunta no trobada",
+                module="DiaryQuestionResource",
+                error=e,
+            )
+            abort(404, message=str(e))
+        except Exception as e:
+            self.logger.error("Error inesperat en recuperar preguntes", module="DiaryQuestionResource", error=e)
+            abort(500, message=f"S'ha produït un error inesperat en recuperar la pregunta del diari: {str(e)}")


### PR DESCRIPTION
This pull request introduces support for a new "diary" question type, including backend infrastructure, API endpoint, and database migration. The main focus is on enabling retrieval of a special diary question for patients, with supporting changes across the domain, repository, and API layers.

**Support for "diary" question type:**

* Added a new `DIARY` value to the `QuestionType` enum, enabling the system to recognize and handle diary questions.
* Created a database migration to add the `'DIARY'` value to the `questiontype` enum in the database, with upgrade and downgrade logic.

**API and service enhancements:**

* Added a new `/diary` API endpoint (`DiaryQuestionResource`) to retrieve the diary question for patients, including proper error handling and documentation.
* Implemented the `get_diary_question` method in the service and repository layers, allowing retrieval of the diary question by a fixed ID. This includes updates to `QuestionService`, repository interfaces, and the SQLAlchemy repository implementation. [[1]](diffhunk://#diff-a526df00e5af1f40594d649e0cb65a31941c354d07d9819eca4bab6fcddb57acR150-R157) [[2]](diffhunk://#diff-92e38336eac6e59f3e8e618530e597ca388cc2c3428eebf5a43c2b748e094299R251-R259) [[3]](diffhunk://#diff-501425cc26f7f69cff48a445584e49a6296549b0284384732ad9736cd8b0f84dR409-R412) [[4]](diffhunk://#diff-501425cc26f7f69cff48a445584e49a6296549b0284384732ad9736cd8b0f84dR31)

**Configuration and constants:**

* Introduced a new `DIARY_QUESTION_ID` constant in `globals.py` to uniquely identify the diary question in the database.
* Bumped the application version to `0.9.0` to reflect these new features.